### PR TITLE
fix: correct skills path in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/alonw0/web-asset-generator"
   },
   "skills": [
-    "./web-asset-generator"
+    "./skills/web-asset-generator"
   ],
   "repository": "https://github.com/alonw0/web-asset-generator.git",
   "homepage": "https://github.com/alonw0/web-asset-generator",


### PR DESCRIPTION
  ## Description
  The skills path in `.claude-plugin/plugin.json` was incorrectly set, causing plugin loading failures.

  ## Problem
  - Current path: `./web-asset-generator`
  - Actual location: `./skills/web-asset-generator`

  This caused the error:
  skills path not found: .../1.0.0/web-asset-generator

  ## Solution
  Updated the skills path to `./skills/web-asset-generator`.

  ## Type of Change
  - [x] Bug fix

  ## Testing
  - [x] Verified plugin loads correctly after the fix