### PR TITLE
docs: fix marketplace.json location in repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ web-asset-generator/                    # Repository root
 ├── LICENSE                             # MIT License
 ├── CHANGELOG.md                        # Version history
 ├── .claude-plugin/                     # Plugin metadata
-│   └── plugin.json                     # Plugin manifest
-├── marketplace.json                    # Marketplace distribution
+│   ├── plugin.json                     # Plugin manifest
+│   └── marketplace.json                # Marketplace distribution
 ├── docs/                               # Documentation & examples
 └── skills/                             # Skills directory
     └── web-asset-generator/           # ⭐ THE SKILL (copy this folder)


### PR DESCRIPTION
The README showed `marketplace.json` at the repository root, but it
is actually located inside `.claude-plugin/`. This corrects the
repository structure diagram to match the actual file layout.